### PR TITLE
Fix: Correct Open Graph image paths

### DIFF
--- a/404.html
+++ b/404.html
@@ -13,7 +13,7 @@
     <meta property="og:type" content="website">
     <meta property="og:title" content="👀">
     <meta property="og:url" content="https://thu-le.com/404">
-    <meta property="og:image" content="assets/social-media-preview.png">
+    <meta property="og:image" content="/assets/social-media-preview.png">
     
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="👀">

--- a/about.html
+++ b/about.html
@@ -13,7 +13,7 @@
     <meta property="og:type" content="website">
     <meta property="og:title" content="Thu Le &#8901; About">
     <meta property="og:url" content="https://thu-le.com/about">
-    <meta property="og:image" content="assets/social-media-preview.png">
+    <meta property="og:image" content="/assets/social-media-preview.png">
     
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Thu Le &#8901; About">

--- a/blogroll.html
+++ b/blogroll.html
@@ -13,7 +13,7 @@
     <meta property="og:type" content="website">
     <meta property="og:title" content="Thu Le &#8901; Blogroll">
     <meta property="og:url" content="https://thu-le.com/blogroll">
-    <meta property="og:image" content="assets/social-media-preview.png">
+    <meta property="og:image" content="/assets/social-media-preview.png">
     
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Thu Le &#8901; Blogroll">

--- a/colophon.html
+++ b/colophon.html
@@ -15,7 +15,7 @@
     <meta property="og:title" content="Thu Le &#8901; Colophon">
     <meta property="og:description" content="About this site.">
     <meta property="og:url" content="https://thu-le.com/colophon">
-    <meta property="og:image" content="assets/social-media-preview.png">
+    <meta property="og:image" content="/assets/social-media-preview.png">
     
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Thu Le &#8901; Colophon">

--- a/index.html
+++ b/index.html
@@ -15,7 +15,7 @@
     <meta property="og:title" content="Thu Le">
     <meta property="og:description" content="Product designer based in Ho Chi Minh City, Vietnam.">
     <meta property="og:url" content="https://thu-le.com/">
-    <meta property="og:image" content="assets/social-media-preview.png">
+    <meta property="og:image" content="/assets/social-media-preview.png">
     
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Thu Le">

--- a/links.html
+++ b/links.html
@@ -15,7 +15,7 @@
     <meta property="og:title" content="Thu Le &#8901; Links">
     <meta property="og:description" content="Things, ideas, and people's work I find interesting.">
     <meta property="og:url" content="https://thu-le.com/links">
-    <meta property="og:image" content="assets/social-media-preview.png">
+    <meta property="og:image" content="/assets/social-media-preview.png">
     
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Thu Le &#8901; Links">


### PR DESCRIPTION
Hey 👋, just checked out your website, don't know you were aware, but a couple of months ago I literally saw your portfolio on the Deadsimplesite, next to mine! Seems like we submitted our work around the time.

Your digital garden was a bit different at that time if I remember correctly. I actually borrowed some ideas from your site and incorporated them into mine to make it behave the way it does now.

I just finished my [colophon](https://doantranminhthanh.com/colophon) page today and included your site there to acknowledge the inspiration. However, when I ran an Open Graph check on your site, I noticed your open graph image was missing, so I decided to fix it (which I explain below).

## What happened

The main changes include updating the `og:image` meta tag in each HTML file to use an absolute path.

The following files were modified: 
- `404.html`
- `about.html`
- `blogroll.html`
- `colophon.html`
- `index.html`
- `links.html`
 
Each file had its `og:image` meta tag updated to reflect the absolute path.

## Insight

Previously you used relative paths for the OG image (`assets/social-media-preview.png`), therefore the image wouldn't consistently display correctly across various contexts and environments. This is because the relative path is interpreted relative to the current URL (which can vary).

![CleanShot 2024-12-15 at 17 33 23](https://github.com/user-attachments/assets/e3737eab-bb21-4c43-8e60-74b08e69673b)

Result:

![CleanShot 2024-12-15 at 17 33 13](https://github.com/user-attachments/assets/8b831d75-7343-48a9-beae-bb4edea3a7c4)

This PR addresses this by updating all instances of the `og:image` meta tag to use an absolute path (`/assets/social-media-preview.png`).

**Note that all blog pages are using absolute paths correctly; only other pages were affected.**

![CleanShot 2024-12-15 at 18 02 53](https://github.com/user-attachments/assets/da489a1b-dd66-4ce1-8aba-e58b2113db51)

## Proof Of Work 📹

![CleanShot 2024-12-15 at 18 04 28](https://github.com/user-attachments/assets/1f014b09-cd39-4bcf-aab9-ebb5dad9b156)

Result:

![CleanShot 2024-12-15 at 17 42 28](https://github.com/user-attachments/assets/be37b9ba-844f-4a07-8e9b-ef7892da9a4a)

I used Cloudflare Tunnel to temporarily make it live; you could consider using it if you want to test it out before pushing to GitHub.

Hope you have a good week ahead!