### PR TITLE
Remove preload stylesheet links

### DIFF
--- a/404.html
+++ b/404.html
@@ -10,7 +10,6 @@
     <meta name="author" content="Thu Le">
     <meta name="description" content="">
     
-    <link rel="preload" href="/css/styles.css" as="style">
     <link rel="stylesheet" href="/css/styles.css">
     
     <meta property="og:type" content="website">

--- a/about.html
+++ b/about.html
@@ -10,7 +10,6 @@
     <meta name="author" content="Thu Le">
     <meta name="description" content="I’m a product designer and a UX lead based in Sài Gòn, Vietnam.">
     
-    <link rel="preload" href="/css/styles.css" as="style">
     <link rel="stylesheet" href="/css/styles.css">
     
     <meta property="og:type" content="website">

--- a/blog/50-things-i-learned-in-2024.html
+++ b/blog/50-things-i-learned-in-2024.html
@@ -10,7 +10,6 @@
     <meta name="author" content="Thu Le">
     <meta name="description" content="50 interesting things I learned in 2024 from books, conversations, and everyday life.">
     
-    <link rel="preload" href="/css/styles.css" as="style">
     <link rel="stylesheet" href="/css/styles.css">
     
     <meta property="og:type" content="article">

--- a/blog/between-away-and-home.html
+++ b/blog/between-away-and-home.html
@@ -10,7 +10,6 @@
     <meta name="author" content="Thu Le">
     <meta name="description" content="And the paradox of travel.">
     
-    <link rel="preload" href="/css/styles.css" as="style">
     <link rel="stylesheet" href="/css/styles.css">
     
     <meta property="og:type" content="article">

--- a/blog/between-worlds.html
+++ b/blog/between-worlds.html
@@ -10,7 +10,6 @@
     <meta name="author" content="Thu Le">
     <meta name="description" content="From moving between worlds to feeling at home wherever I am.">
     
-    <link rel="preload" href="/css/styles.css" as="style">
     <link rel="stylesheet" href="/css/styles.css">
     
     <meta property="og:type" content="article">

--- a/blog/blind-spots.html
+++ b/blog/blind-spots.html
@@ -10,7 +10,6 @@
     <meta name="author" content="Thu Le">
     <meta name="description" content="Finding my blind spots using AI.">
     
-    <link rel="preload" href="/css/styles.css" as="style">
     <link rel="stylesheet" href="/css/styles.css">
     
     <meta property="og:type" content="article">

--- a/blog/blog-questions-challenge.html
+++ b/blog/blog-questions-challenge.html
@@ -10,7 +10,6 @@
 	<meta name="author" content="Thu Le">
 	<meta name="description" content="I’m answering questions in the blog questions challenge!">
 	
-	<link rel="preload" href="/css/styles.css" as="style">
 	<link rel="stylesheet" href="/css/styles.css">
 	
 	<meta property="og:type" content="article">

--- a/blog/going-back-to-the-beach.html
+++ b/blog/going-back-to-the-beach.html
@@ -10,7 +10,6 @@
     <meta name="author" content="Thu Le">
     <meta name="description" content="My quiet ritual of comfort.">
     
-    <link rel="preload" href="/css/styles.css" as="style">
     <link rel="stylesheet" href="/css/styles.css">
     
     <meta property="og:type" content="article">

--- a/blog/good-work.html
+++ b/blog/good-work.html
@@ -10,7 +10,6 @@
     <meta name="author" content="Thu Le">
     <meta name="description" content="My journey into design and the search for good work.">
     
-    <link rel="preload" href="/css/styles.css" as="style">
     <link rel="stylesheet" href="/css/styles.css">
     
     <meta property="og:type" content="article">

--- a/blog/imperfections.html
+++ b/blog/imperfections.html
@@ -10,7 +10,6 @@
     <meta name="author" content="Thu Le">
     <meta name="description" content="Things don’t have to be perfect to be meaningful.">
     
-    <link rel="preload" href="/css/styles.css" as="style">
     <link rel="stylesheet" href="/css/styles.css">
     
     <meta property="og:type" content="article">

--- a/blog/index.html
+++ b/blog/index.html
@@ -10,7 +10,6 @@
     <meta name="author" content="Thu Le">
     <meta name="description" content="Musings on intentional living, productivity, and everyday life.">
     
-    <link rel="preload" href="/css/styles.css" as="style">
     <link rel="stylesheet" href="/css/styles.css">
     
     <meta property="og:type" content="website">

--- a/blog/my-design-process.html
+++ b/blog/my-design-process.html
@@ -10,7 +10,6 @@
     <meta name="author" content="Thu Le">
     <meta name="description" content="">
     
-    <link rel="preload" href="/css/styles.css" as="style">
     <link rel="stylesheet" href="/css/styles.css">
     
     <meta property="og:type" content="article">

--- a/blog/on-running.html
+++ b/blog/on-running.html
@@ -10,7 +10,6 @@
     <meta name="author" content="Thu Le">
     <meta name="description" content="I went from hating running to accidentally enjoying it.">
     
-    <link rel="preload" href="/css/styles.css" as="style">
     <link rel="stylesheet" href="/css/styles.css">
     
     <meta property="og:type" content="article">

--- a/blog/on-selling.html
+++ b/blog/on-selling.html
@@ -10,7 +10,6 @@
     <meta name="author" content="Thu Le">
     <meta name="description" content="Some thoughts on selling, URL and IRL.">
     
-    <link rel="preload" href="/css/styles.css" as="style">
     <link rel="stylesheet" href="/css/styles.css">
     
     <meta property="og:type" content="article">

--- a/blog/pen-and-paper.html
+++ b/blog/pen-and-paper.html
@@ -10,7 +10,6 @@
     <meta name="author" content="Thu Le">
     <meta name="description" content="The tactile joy of thinking with lines on paper.">
     
-    <link rel="preload" href="/css/styles.css" as="style">
     <link rel="stylesheet" href="/css/styles.css">
     
     <meta property="og:type" content="article">

--- a/blog/personal-manifesto.html
+++ b/blog/personal-manifesto.html
@@ -10,7 +10,6 @@
     <meta name="author" content="Thu Le">
     <meta name="description" content="Operating principles for how I think, relate, and work.">
     
-    <link rel="preload" href="/css/styles.css" as="style">
     <link rel="stylesheet" href="/css/styles.css">
     
     <meta property="og:type" content="article">

--- a/blog/presence-over-performance.html
+++ b/blog/presence-over-performance.html
@@ -10,7 +10,6 @@
 	<meta name="author" content="Thu Le">
 	<meta name="description" content="A reflection on curating an online persona and choosing to live a quieter life.">
 	
-	<link rel="preload" href="/css/styles.css" as="style">
 	<link rel="stylesheet" href="/css/styles.css">
 	
 	<meta property="og:type" content="article">

--- a/blog/reading-out-loud.html
+++ b/blog/reading-out-loud.html
@@ -10,7 +10,6 @@
     <meta name="author" content="Thu Le">
     <meta name="description" content="Lately I find myself reading stuff out loud and enjoying it.">
     
-    <link rel="preload" href="/css/styles.css" as="style">
     <link rel="stylesheet" href="/css/styles.css">
     
     <meta property="og:type" content="article">

--- a/blog/stubborn-determination.html
+++ b/blog/stubborn-determination.html
@@ -10,7 +10,6 @@
     <meta name="author" content="Thu Le">
     <meta name="description" content="What music hunts, design struggles, and running have in common.">
     
-    <link rel="preload" href="/css/styles.css" as="style">
     <link rel="stylesheet" href="/css/styles.css">
     
     <meta property="og:type" content="article">

--- a/blog/ten-pointless-facts-about-me.html
+++ b/blog/ten-pointless-facts-about-me.html
@@ -10,7 +10,6 @@
     <meta name="author" content="Thu Le">
     <meta name="description" content="Maybe the first of who knows how many.">
     
-    <link rel="preload" href="/css/styles.css" as="style">
     <link rel="stylesheet" href="/css/styles.css">
     
     <meta property="og:type" content="article">

--- a/blog/the-journey-and-the-destination.html
+++ b/blog/the-journey-and-the-destination.html
@@ -10,7 +10,6 @@
     <meta name="author" content="Thu Le">
     <meta name="description" content="When is it about the journey, and can it also be the destination?">
     
-    <link rel="preload" href="/css/styles.css" as="style">
     <link rel="stylesheet" href="/css/styles.css">
     
     <meta property="og:type" content="article">

--- a/blog/things-i-have-changed-my-mind-about-lately.html
+++ b/blog/things-i-have-changed-my-mind-about-lately.html
@@ -10,7 +10,6 @@
     <meta name="author" content="Thu Le">
     <meta name="description" content="On music preferences, having a TV in the bedroom, solitude, mechanical keyboards, and productivity.">
     
-    <link rel="preload" href="/css/styles.css" as="style">
     <link rel="stylesheet" href="/css/styles.css">
     
     <meta property="og:type" content="article">

--- a/blog/things-i-know.html
+++ b/blog/things-i-know.html
@@ -10,7 +10,6 @@
     <meta name="author" content="Thu Le">
     <meta name="description" content="I turned 30 and here are some things I’ve learned along the way.">
     
-    <link rel="preload" href="/css/styles.css" as="style">
     <link rel="stylesheet" href="/css/styles.css">
     
     <meta property="og:type" content="article">

--- a/blog/things-worth-spending-on.html
+++ b/blog/things-worth-spending-on.html
@@ -10,7 +10,6 @@
     <meta name="author" content="Thu Le">
     <meta name="description" content="Worthwhile investments, in my experience, and occasional treats that make my day more delightful.">
     
-    <link rel="preload" href="/css/styles.css" as="style">
     <link rel="stylesheet" href="/css/styles.css">
     
     <meta property="og:type" content="article">

--- a/blog/why-i-rebuilt-this-site.html
+++ b/blog/why-i-rebuilt-this-site.html
@@ -10,7 +10,6 @@
     <meta name="author" content="Thu Le">
     <meta name="description" content="The journey of building this site.">
     
-    <link rel="preload" href="/css/styles.css" as="style">
     <link rel="stylesheet" href="/css/styles.css">
     
     <meta property="og:type" content="article">

--- a/blogroll.html
+++ b/blogroll.html
@@ -10,7 +10,6 @@
     <meta name="author" content="Thu Le">
     <meta name="description" content="Blogs and sites I enjoy reading.">
     
-    <link rel="preload" href="/css/styles.css" as="style">
     <link rel="stylesheet" href="/css/styles.css">
     
     <meta property="og:type" content="website">

--- a/colophon.html
+++ b/colophon.html
@@ -10,7 +10,6 @@
     <meta name="author" content="Thu Le">
     <meta name="description" content="How this site is built.">
     
-    <link rel="preload" href="/css/styles.css" as="style">
     <link rel="stylesheet" href="/css/styles.css">
     
     <meta property="og:type" content="website">

--- a/index.html
+++ b/index.html
@@ -10,7 +10,6 @@
     <meta name="author" content="Thu Le">
     <meta name="description" content="Designer who builds and writes. Powered by coffee and matcha.">
     
-    <link rel="preload" href="/css/styles.css" as="style">
     <link rel="stylesheet" href="/css/styles.css">
     
     <meta property="og:type" content="website">

--- a/links.html
+++ b/links.html
@@ -10,7 +10,6 @@
     <meta name="author" content="Thu Le">
     <meta name="description" content="Things, ideas, and people’s work I find interesting.">
     
-    <link rel="preload" href="/css/styles.css" as="style">
     <link rel="stylesheet" href="/css/styles.css">
     
     <meta property="og:type" content="website">

--- a/now/2025-may.html
+++ b/now/2025-may.html
@@ -10,7 +10,6 @@
     <meta name="author" content="Thu Le">
     <meta name="description" content="Trying a new format for my /Now updates.">
     
-    <link rel="preload" href="/css/styles.css" as="style">
     <link rel="stylesheet" href="/css/styles.css">
     
     <meta property="og:type" content="article">

--- a/now/index.html
+++ b/now/index.html
@@ -10,7 +10,6 @@
     <meta name="author" content="Thu Le">
     <meta name="description" content="What I’m doing now.">
     
-    <link rel="preload" href="/css/styles.css" as="style">
     <link rel="stylesheet" href="/css/styles.css">
     
     <meta property="og:type" content="website">

--- a/uses.html
+++ b/uses.html
@@ -10,7 +10,6 @@
     <meta name="author" content="Thu Le">
     <meta name="description" content="Tools and apps that are my daily drivers.">
     
-    <link rel="preload" href="/css/styles.css" as="style">
     <link rel="stylesheet" href="/css/styles.css">
     
     <meta property="og:type" content="website">


### PR DESCRIPTION
## Summary
- remove redundant preload link and rely on standard stylesheet link

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688edbef94808325ac3ab69ab3664405