### PR TITLE
Use single favicon across site

### DIFF
--- a/404.html
+++ b/404.html
@@ -22,9 +22,7 @@
     <meta name="twitter:site" content="@_tple">
     <meta name="twitter:image" content="/assets/social-media-preview.png">
     
-    <link rel="icon" href="/assets/favicon-light-fill.png" type="image/png" media="(prefers-color-scheme: light)">
-    <link rel="icon" href="/assets/favicon-dark-fill.png" type="image/png" media="(prefers-color-scheme: dark)">
-    <link rel="icon" href="/assets/favicon-light-fill.png" type="image/png">
+    <link rel="icon" type="image/png" href="/assets/favicon.png">
     <link rel="apple-touch-icon" href="/assets/apple-icon.png" sizes="192x192">
     
     <script defer src="https://cloud.umami.is/script.js" data-website-id="e21ce1e3-9e78-42f6-ac48-fd87995bedc0"></script>

--- a/about.html
+++ b/about.html
@@ -25,9 +25,7 @@
     <meta name="twitter:description" content="I’m a product designer and a UX lead based in Sài Gòn, Vietnam.">
     <meta name="twitter:image" content="/images/about/rome_2025.webp">
     
-    <link rel="icon" href="/assets/favicon-light-fill.png" type="image/png" media="(prefers-color-scheme: light)">
-    <link rel="icon" href="/assets/favicon-dark-fill.png" type="image/png" media="(prefers-color-scheme: dark)">
-    <link rel="icon" href="/assets/favicon-light-fill.png" type="image/png">
+    <link rel="icon" type="image/png" href="/assets/favicon.png">
     <link rel="apple-touch-icon" href="/assets/apple-icon.png" sizes="192x192">
     
     <script defer src="https://cloud.umami.is/script.js" data-website-id="e21ce1e3-9e78-42f6-ac48-fd87995bedc0"></script>

--- a/blog/50-things-i-learned-in-2024.html
+++ b/blog/50-things-i-learned-in-2024.html
@@ -25,9 +25,7 @@
     <meta name="twitter:description" content="50 interesting things I learned in 2024 from books, conversations, and everyday life.">
     <meta name="twitter:image" content="/assets/social-media-preview.png">
     
-    <link rel="icon" href="/assets/favicon-light-fill.png" type="image/png" media="(prefers-color-scheme: light)">
-    <link rel="icon" href="/assets/favicon-dark-fill.png" type="image/png" media="(prefers-color-scheme: dark)">
-    <link rel="icon" href="/assets/favicon-light-fill.png" type="image/png">
+    <link rel="icon" type="image/png" href="/assets/favicon.png">
     <link rel="apple-touch-icon" href="/assets/apple-icon.png" sizes="192x192">
     
     <script defer src="https://cloud.umami.is/script.js" data-website-id="e21ce1e3-9e78-42f6-ac48-fd87995bedc0"></script>

--- a/blog/between-away-and-home.html
+++ b/blog/between-away-and-home.html
@@ -25,9 +25,7 @@
     <meta name="twitter:description" content="And the paradox of travel.">
     <meta name="twitter:image" content="/blog/images/paris-morning.jpeg">
     
-    <link rel="icon" href="/assets/favicon-light-fill.png" type="image/png" media="(prefers-color-scheme: light)">
-    <link rel="icon" href="/assets/favicon-dark-fill.png" type="image/png" media="(prefers-color-scheme: dark)">
-    <link rel="icon" href="/assets/favicon-light-fill.png" type="image/png">
+    <link rel="icon" type="image/png" href="/assets/favicon.png">
     <link rel="apple-touch-icon" href="/assets/apple-icon.png" sizes="192x192">
     
     <script defer src="https://cloud.umami.is/script.js" data-website-id="e21ce1e3-9e78-42f6-ac48-fd87995bedc0"></script>

--- a/blog/between-worlds.html
+++ b/blog/between-worlds.html
@@ -25,9 +25,7 @@
     <meta name="twitter:description" content="From moving between worlds to feeling at home wherever I am.">
     <meta name="twitter:image" content="/blog/images/airplane.webp">
     
-    <link rel="icon" href="/assets/favicon-light-fill.png" type="image/png" media="(prefers-color-scheme: light)">
-    <link rel="icon" href="/assets/favicon-dark-fill.png" type="image/png" media="(prefers-color-scheme: dark)">
-    <link rel="icon" href="/assets/favicon-light-fill.png" type="image/png">
+    <link rel="icon" type="image/png" href="/assets/favicon.png">
     <link rel="apple-touch-icon" href="/assets/apple-icon.png" sizes="192x192">
     
     <script defer src="https://cloud.umami.is/script.js" data-website-id="e21ce1e3-9e78-42f6-ac48-fd87995bedc0"></script>

--- a/blog/blind-spots.html
+++ b/blog/blind-spots.html
@@ -25,9 +25,7 @@
     <meta name="twitter:description" content="Finding my blind spots using AI.">
     <meta name="twitter:image" content="/assets/social-media-preview.png">
     
-    <link rel="icon" href="/assets/favicon-light-fill.png" type="image/png" media="(prefers-color-scheme: light)">
-    <link rel="icon" href="/assets/favicon-dark-fill.png" type="image/png" media="(prefers-color-scheme: dark)">
-    <link rel="icon" href="/assets/favicon-light-fill.png" type="image/png">
+    <link rel="icon" type="image/png" href="/assets/favicon.png">
     <link rel="apple-touch-icon" href="/assets/apple-icon.png" sizes="192x192">
     
     <script defer src="https://cloud.umami.is/script.js" data-website-id="e21ce1e3-9e78-42f6-ac48-fd87995bedc0"></script>

--- a/blog/blog-questions-challenge.html
+++ b/blog/blog-questions-challenge.html
@@ -25,10 +25,8 @@
 	<meta name="twitter:description" content="I’m answering questions in the blog questions challenge!">
 	<meta name="twitter:image" content="/assets/social-media-preview.png">
 	
-	<link rel="icon" href="/assets/favicon-light-fill.png" type="image/png" media="(prefers-color-scheme: light)">
-	<link rel="icon" href="/assets/favicon-dark-fill.png" type="image/png" media="(prefers-color-scheme: dark)">
-	<link rel="icon" href="/assets/favicon-light-fill.png" type="image/png">
-	<link rel="apple-touch-icon" href="/assets/apple-icon.png" sizes="192x192">
+	<link rel="icon" type="image/png" href="/assets/favicon.png">
+    <link rel="apple-touch-icon" href="/assets/apple-icon.png" sizes="192x192">
 	
 	<script defer src="https://cloud.umami.is/script.js" data-website-id="e21ce1e3-9e78-42f6-ac48-fd87995bedc0"></script>
 </head>

--- a/blog/going-back-to-the-beach.html
+++ b/blog/going-back-to-the-beach.html
@@ -25,9 +25,7 @@
     <meta name="twitter:description" content="My quiet ritual of comfort.">
     <meta name="twitter:image" content="/blog/images/mui_ne_beach.webp">
     
-    <link rel="icon" href="/assets/favicon-light-fill.png" type="image/png" media="(prefers-color-scheme: light)">
-    <link rel="icon" href="/assets/favicon-dark-fill.png" type="image/png" media="(prefers-color-scheme: dark)">
-    <link rel="icon" href="/assets/favicon-light-fill.png" type="image/png">
+    <link rel="icon" type="image/png" href="/assets/favicon.png">
     <link rel="apple-touch-icon" href="/assets/apple-icon.png" sizes="192x192">
     
     <script defer src="https://cloud.umami.is/script.js" data-website-id="e21ce1e3-9e78-42f6-ac48-fd87995bedc0"></script>

--- a/blog/good-work.html
+++ b/blog/good-work.html
@@ -25,9 +25,7 @@
     <meta name="twitter:description" content="My journey into design and the search for good work.">
     <meta name="twitter:image" content="/assets/social-media-preview.png">
     
-    <link rel="icon" href="/assets/favicon-light-fill.png" type="image/png" media="(prefers-color-scheme: light)">
-    <link rel="icon" href="/assets/favicon-dark-fill.png" type="image/png" media="(prefers-color-scheme: dark)">
-    <link rel="icon" href="/assets/favicon-light-fill.png" type="image/png">
+    <link rel="icon" type="image/png" href="/assets/favicon.png">
     <link rel="apple-touch-icon" href="/assets/apple-icon.png" sizes="192x192">
     
     <script defer src="https://cloud.umami.is/script.js" data-website-id="e21ce1e3-9e78-42f6-ac48-fd87995bedc0"></script>

--- a/blog/imperfections.html
+++ b/blog/imperfections.html
@@ -25,9 +25,7 @@
     <meta name="twitter:description" content="Things don’t have to be perfect to be meaningful.">
     <meta name="twitter:image" content="/blog/images/trackpad.webp">
     
-    <link rel="icon" href="/assets/favicon-light-fill.png" type="image/png" media="(prefers-color-scheme: light)">
-    <link rel="icon" href="/assets/favicon-dark-fill.png" type="image/png" media="(prefers-color-scheme: dark)">
-    <link rel="icon" href="/assets/favicon-light-fill.png" type="image/png">
+    <link rel="icon" type="image/png" href="/assets/favicon.png">
     <link rel="apple-touch-icon" href="/assets/apple-icon.png" sizes="192x192">
     
     <script defer src="https://cloud.umami.is/script.js" data-website-id="e21ce1e3-9e78-42f6-ac48-fd87995bedc0"></script>

--- a/blog/index.html
+++ b/blog/index.html
@@ -25,9 +25,7 @@
     <meta name="twitter:description" content="Musings on intentional living, productivity, and everyday life.">
     <meta name="twitter:image" content="/assets/social-media-preview.png">
     
-    <link rel="icon" href="/assets/favicon-light-fill.png" type="image/png" media="(prefers-color-scheme: light)">
-    <link rel="icon" href="/assets/favicon-dark-fill.png" type="image/png" media="(prefers-color-scheme: dark)">
-    <link rel="icon" href="/assets/favicon-light-fill.png" type="image/png">
+    <link rel="icon" type="image/png" href="/assets/favicon.png">
     <link rel="apple-touch-icon" href="/assets/apple-icon.png" sizes="192x192">
     
     <link rel="alternate" type="application/rss+xml" title="Thu Le" href="/feed.xml">

--- a/blog/my-design-process.html
+++ b/blog/my-design-process.html
@@ -25,9 +25,7 @@
     <meta name="twitter:description" content="How I collect, connect, and correct the dots in my product design process.">
     <meta name="twitter:image" content="/blog/images/ds-bk.webp">
     
-    <link rel="icon" href="/assets/favicon-light-fill.png" type="image/png" media="(prefers-color-scheme: light)">
-    <link rel="icon" href="/assets/favicon-dark-fill.png" type="image/png" media="(prefers-color-scheme: dark)">
-    <link rel="icon" href="/assets/favicon-light-fill.png" type="image/png">
+    <link rel="icon" type="image/png" href="/assets/favicon.png">
     <link rel="apple-touch-icon" href="/assets/apple-icon.png" sizes="192x192">
     
     <script defer src="https://cloud.umami.is/script.js" data-website-id="e21ce1e3-9e78-42f6-ac48-fd87995bedc0"></script>

--- a/blog/on-running.html
+++ b/blog/on-running.html
@@ -25,9 +25,7 @@
     <meta name="twitter:description" content="I went from hating running to accidentally enjoying it.">
     <meta name="twitter:image" content="/assets/social-media-preview.png">
     
-    <link rel="icon" href="/assets/favicon-light-fill.png" type="image/png" media="(prefers-color-scheme: light)">
-    <link rel="icon" href="/assets/favicon-dark-fill.png" type="image/png" media="(prefers-color-scheme: dark)">
-    <link rel="icon" href="/assets/favicon-light-fill.png" type="image/png">
+    <link rel="icon" type="image/png" href="/assets/favicon.png">
     <link rel="apple-touch-icon" href="/assets/apple-icon.png" sizes="192x192">
     
     <script defer src="https://cloud.umami.is/script.js" data-website-id="e21ce1e3-9e78-42f6-ac48-fd87995bedc0"></script>

--- a/blog/on-selling.html
+++ b/blog/on-selling.html
@@ -25,9 +25,7 @@
     <meta name="twitter:description" content="Some thoughts on selling, URL and IRL.">
     <meta name="twitter:image" content="/assets/social-media-preview.png">
     
-    <link rel="icon" href="/assets/favicon-light-fill.png" type="image/png" media="(prefers-color-scheme: light)">
-    <link rel="icon" href="/assets/favicon-dark-fill.png" type="image/png" media="(prefers-color-scheme: dark)">
-    <link rel="icon" href="/assets/favicon-light-fill.png" type="image/png">
+    <link rel="icon" type="image/png" href="/assets/favicon.png">
     <link rel="apple-touch-icon" href="/assets/apple-icon.png" sizes="192x192">
     
     <script defer src="https://cloud.umami.is/script.js" data-website-id="e21ce1e3-9e78-42f6-ac48-fd87995bedc0"></script>

--- a/blog/pen-and-paper.html
+++ b/blog/pen-and-paper.html
@@ -25,9 +25,7 @@
     <meta name="twitter:description" content="The tactile joy of thinking with lines on paper.">
     <meta name="twitter:image" content="/blog/images/paper-sketches.webp">
     
-    <link rel="icon" href="/assets/favicon-light-fill.png" type="image/png" media="(prefers-color-scheme: light)">
-    <link rel="icon" href="/assets/favicon-dark-fill.png" type="image/png" media="(prefers-color-scheme: dark)">
-    <link rel="icon" href="/assets/favicon-light-fill.png" type="image/png">
+    <link rel="icon" type="image/png" href="/assets/favicon.png">
     <link rel="apple-touch-icon" href="/assets/apple-icon.png" sizes="192x192">
     
     <script defer src="https://cloud.umami.is/script.js" data-website-id="e21ce1e3-9e78-42f6-ac48-fd87995bedc0"></script>

--- a/blog/personal-manifesto.html
+++ b/blog/personal-manifesto.html
@@ -25,9 +25,7 @@
     <meta name="twitter:description" content="Operating principles for how I think, relate, and work.">
     <meta name="twitter:image" content="/assets/social-media-preview.png">
     
-    <link rel="icon" href="/assets/favicon-light-fill.png" type="image/png" media="(prefers-color-scheme: light)">
-    <link rel="icon" href="/assets/favicon-dark-fill.png" type="image/png" media="(prefers-color-scheme: dark)">
-    <link rel="icon" href="/assets/favicon-light-fill.png" type="image/png">
+    <link rel="icon" type="image/png" href="/assets/favicon.png">
     <link rel="apple-touch-icon" href="/assets/apple-icon.png" sizes="192x192">
     
     <script defer src="https://cloud.umami.is/script.js" data-website-id="e21ce1e3-9e78-42f6-ac48-fd87995bedc0"></script>

--- a/blog/presence-over-performance.html
+++ b/blog/presence-over-performance.html
@@ -25,10 +25,8 @@
 	<meta name="twitter:description" content="A reflection on curating an online persona and choosing to live a quieter life.">
 	<meta name="twitter:image" content="/assets/social-media-preview.png">
 	
-	<link rel="icon" href="/assets/favicon-light-fill.png" type="image/png" media="(prefers-color-scheme: light)">
-	<link rel="icon" href="/assets/favicon-dark-fill.png" type="image/png" media="(prefers-color-scheme: dark)">
-	<link rel="icon" href="/assets/favicon-light-fill.png" type="image/png">
-	<link rel="apple-touch-icon" href="/assets/apple-icon.png" sizes="192x192">
+	<link rel="icon" type="image/png" href="/assets/favicon.png">
+    <link rel="apple-touch-icon" href="/assets/apple-icon.png" sizes="192x192">
 	
 	<script defer src="https://cloud.umami.is/script.js" data-website-id="e21ce1e3-9e78-42f6-ac48-fd87995bedc0"></script>
 </head>

--- a/blog/reading-out-loud.html
+++ b/blog/reading-out-loud.html
@@ -25,9 +25,7 @@
     <meta name="twitter:description" content="Lately I find myself reading stuff out loud and enjoying it.">
     <meta name="twitter:image" content="/assets/social-media-preview.png">
     
-    <link rel="icon" href="/assets/favicon-light-fill.png" type="image/png" media="(prefers-color-scheme: light)">
-    <link rel="icon" href="/assets/favicon-dark-fill.png" type="image/png" media="(prefers-color-scheme: dark)">
-    <link rel="icon" href="/assets/favicon-light-fill.png" type="image/png">
+    <link rel="icon" type="image/png" href="/assets/favicon.png">
     <link rel="apple-touch-icon" href="/assets/apple-icon.png" sizes="192x192">
     
     <script defer src="https://cloud.umami.is/script.js" data-website-id="e21ce1e3-9e78-42f6-ac48-fd87995bedc0"></script>

--- a/blog/stubborn-determination.html
+++ b/blog/stubborn-determination.html
@@ -25,9 +25,7 @@
     <meta name="twitter:description" content="What music hunts, design struggles, and running have in common.">
     <meta name="twitter:image" content="/assets/social-media-preview.png">
     
-    <link rel="icon" href="/assets/favicon-light-fill.png" type="image/png" media="(prefers-color-scheme: light)">
-    <link rel="icon" href="/assets/favicon-dark-fill.png" type="image/png" media="(prefers-color-scheme: dark)">
-    <link rel="icon" href="/assets/favicon-light-fill.png" type="image/png">
+    <link rel="icon" type="image/png" href="/assets/favicon.png">
     <link rel="apple-touch-icon" href="/assets/apple-icon.png" sizes="192x192">
     
     <script defer src="https://cloud.umami.is/script.js" data-website-id="e21ce1e3-9e78-42f6-ac48-fd87995bedc0"></script>

--- a/blog/ten-pointless-facts-about-me.html
+++ b/blog/ten-pointless-facts-about-me.html
@@ -25,9 +25,7 @@
     <meta name="twitter:description" content="Maybe the first of who knows how many.">
     <meta name="twitter:image" content="/assets/social-media-preview.png">
     
-    <link rel="icon" href="/assets/favicon-light-fill.png" type="image/png" media="(prefers-color-scheme: light)">
-    <link rel="icon" href="/assets/favicon-dark-fill.png" type="image/png" media="(prefers-color-scheme: dark)">
-    <link rel="icon" href="/assets/favicon-light-fill.png" type="image/png">
+    <link rel="icon" type="image/png" href="/assets/favicon.png">
     <link rel="apple-touch-icon" href="/assets/apple-icon.png" sizes="192x192">
     
     <script defer src="https://cloud.umami.is/script.js" data-website-id="e21ce1e3-9e78-42f6-ac48-fd87995bedc0"></script>

--- a/blog/the-journey-and-the-destination.html
+++ b/blog/the-journey-and-the-destination.html
@@ -25,9 +25,7 @@
     <meta name="twitter:description" content="When is it about the journey, and can it also be the destination?">
     <meta name="twitter:image" content="/blog/images/sala-early-evening.webp">
     
-    <link rel="icon" href="/assets/favicon-light-fill.png" type="image/png" media="(prefers-color-scheme: light)">
-    <link rel="icon" href="/assets/favicon-dark-fill.png" type="image/png" media="(prefers-color-scheme: dark)">
-    <link rel="icon" href="/assets/favicon-light-fill.png" type="image/png">
+    <link rel="icon" type="image/png" href="/assets/favicon.png">
     <link rel="apple-touch-icon" href="/assets/apple-icon.png" sizes="192x192">
     
     <script defer src="https://cloud.umami.is/script.js" data-website-id="e21ce1e3-9e78-42f6-ac48-fd87995bedc0"></script>

--- a/blog/things-i-have-changed-my-mind-about-lately.html
+++ b/blog/things-i-have-changed-my-mind-about-lately.html
@@ -25,9 +25,7 @@
     <meta name="twitter:description" content="On music preferences, having a TV in the bedroom, solitude, mechanical keyboards, and productivity.">
     <meta name="twitter:image" content="/assets/social-media-preview.png">
     
-    <link rel="icon" href="/assets/favicon-light-fill.png" type="image/png" media="(prefers-color-scheme: light)">
-    <link rel="icon" href="/assets/favicon-dark-fill.png" type="image/png" media="(prefers-color-scheme: dark)">
-    <link rel="icon" href="/assets/favicon-light-fill.png" type="image/png">
+    <link rel="icon" type="image/png" href="/assets/favicon.png">
     <link rel="apple-touch-icon" href="/assets/apple-icon.png" sizes="192x192">
     
     <script defer src="https://cloud.umami.is/script.js" data-website-id="e21ce1e3-9e78-42f6-ac48-fd87995bedc0"></script>

--- a/blog/things-i-know.html
+++ b/blog/things-i-know.html
@@ -25,9 +25,7 @@
     <meta name="twitter:description" content="I turned 30 and here are some things I’ve learned along the way.">
     <meta name="twitter:image" content="/blog/images/wilderness.webp">
     
-    <link rel="icon" href="/assets/favicon-light-fill.png" type="image/png" media="(prefers-color-scheme: light)">
-    <link rel="icon" href="/assets/favicon-dark-fill.png" type="image/png" media="(prefers-color-scheme: dark)">
-    <link rel="icon" href="/assets/favicon-light-fill.png" type="image/png">
+    <link rel="icon" type="image/png" href="/assets/favicon.png">
     <link rel="apple-touch-icon" href="/assets/apple-icon.png" sizes="192x192">
     
     <script defer src="https://cloud.umami.is/script.js" data-website-id="e21ce1e3-9e78-42f6-ac48-fd87995bedc0"></script>

--- a/blog/things-worth-spending-on.html
+++ b/blog/things-worth-spending-on.html
@@ -25,9 +25,7 @@
     <meta name="twitter:description" content="Worthwhile investments, in my experience, and occasional treats that make my day more delightful.">
     <meta name="twitter:image" content="/blog/images/iced-latte.webp">
     
-    <link rel="icon" href="/assets/favicon-light-fill.png" type="image/png" media="(prefers-color-scheme: light)">
-    <link rel="icon" href="/assets/favicon-dark-fill.png" type="image/png" media="(prefers-color-scheme: dark)">
-    <link rel="icon" href="/assets/favicon-light-fill.png" type="image/png">
+    <link rel="icon" type="image/png" href="/assets/favicon.png">
     <link rel="apple-touch-icon" href="/assets/apple-icon.png" sizes="192x192">
     
     <script defer src="https://cloud.umami.is/script.js" data-website-id="e21ce1e3-9e78-42f6-ac48-fd87995bedc0"></script>

--- a/blog/why-i-rebuilt-this-site.html
+++ b/blog/why-i-rebuilt-this-site.html
@@ -25,9 +25,7 @@
     <meta name="twitter:description" content="The journey of building this site.">
     <meta name="twitter:image" content="/assets/social-media-preview.png">
     
-    <link rel="icon" href="/assets/favicon-light-fill.png" type="image/png" media="(prefers-color-scheme: light)">
-    <link rel="icon" href="/assets/favicon-dark-fill.png" type="image/png" media="(prefers-color-scheme: dark)">
-    <link rel="icon" href="/assets/favicon-light-fill.png" type="image/png">
+    <link rel="icon" type="image/png" href="/assets/favicon.png">
     <link rel="apple-touch-icon" href="/assets/apple-icon.png" sizes="192x192">
     
     <script defer src="https://cloud.umami.is/script.js" data-website-id="e21ce1e3-9e78-42f6-ac48-fd87995bedc0"></script>

--- a/blogroll.html
+++ b/blogroll.html
@@ -25,9 +25,7 @@
     <meta name="twitter:description" content="Blogs and sites I enjoy reading.">
     <meta name="twitter:image" content="/assets/social-media-preview.png">
     
-    <link rel="icon" href="/assets/favicon-light-fill.png" type="image/png" media="(prefers-color-scheme: light)">
-    <link rel="icon" href="/assets/favicon-dark-fill.png" type="image/png" media="(prefers-color-scheme: dark)">
-    <link rel="icon" href="/assets/favicon-light-fill.png" type="image/png">
+    <link rel="icon" type="image/png" href="/assets/favicon.png">
     <link rel="apple-touch-icon" href="/assets/apple-icon.png" sizes="192x192">
     
     <script defer src="https://cloud.umami.is/script.js" data-website-id="e21ce1e3-9e78-42f6-ac48-fd87995bedc0"></script>

--- a/colophon.html
+++ b/colophon.html
@@ -25,9 +25,7 @@
     <meta name="twitter:description" content="How this site is built.">
     <meta name="twitter:image" content="/assets/social-media-preview.png">
     
-    <link rel="icon" href="/assets/favicon-light-fill.png" type="image/png" media="(prefers-color-scheme: light)">
-    <link rel="icon" href="/assets/favicon-dark-fill.png" type="image/png" media="(prefers-color-scheme: dark)">
-    <link rel="icon" href="/assets/favicon-light-fill.png" type="image/png">
+    <link rel="icon" type="image/png" href="/assets/favicon.png">
     <link rel="apple-touch-icon" href="/assets/apple-icon.png" sizes="192x192">
     
     <script defer src="https://cloud.umami.is/script.js" data-website-id="e21ce1e3-9e78-42f6-ac48-fd87995bedc0"></script>

--- a/index.html
+++ b/index.html
@@ -25,9 +25,7 @@
     <meta name="twitter:description" content="Designer who builds and writes. Powered by coffee and matcha.">
     <meta name="twitter:image" content="/assets/social-media-preview.png">
     
-    <link rel="icon" href="/assets/favicon-light-fill.png" type="image/png" media="(prefers-color-scheme: light)">
-    <link rel="icon" href="/assets/favicon-dark-fill.png" type="image/png" media="(prefers-color-scheme: dark)">
-    <link rel="icon" href="/assets/favicon-light-fill.png" type="image/png">
+    <link rel="icon" type="image/png" href="/assets/favicon.png">
     <link rel="apple-touch-icon" href="/assets/apple-icon.png" sizes="192x192">
     
     <link rel="alternate" type="application/rss+xml" title="Thu Le" href="/feed.xml">

--- a/links.html
+++ b/links.html
@@ -25,9 +25,7 @@
     <meta name="twitter:description" content="Things, ideas, and people’s work I find interesting.">
     <meta name="twitter:image" content="/assets/social-media-preview.png">
     
-    <link rel="icon" href="/assets/favicon-light-fill.png" type="image/png" media="(prefers-color-scheme: light)">
-    <link rel="icon" href="/assets/favicon-dark-fill.png" type="image/png" media="(prefers-color-scheme: dark)">
-    <link rel="icon" href="/assets/favicon-light-fill.png" type="image/png">
+    <link rel="icon" type="image/png" href="/assets/favicon.png">
     <link rel="apple-touch-icon" href="/assets/apple-icon.png" sizes="192x192">
     
     <script defer src="https://cloud.umami.is/script.js" data-website-id="e21ce1e3-9e78-42f6-ac48-fd87995bedc0"></script>

--- a/now/2025-may.html
+++ b/now/2025-may.html
@@ -25,9 +25,7 @@
     <meta name="twitter:description" content="Trying a new format for my /Now updates.">
     <meta name="twitter:image" content="/assets/social-media-preview.png">
     
-    <link rel="icon" href="/assets/favicon-light-fill.png" type="image/png" media="(prefers-color-scheme: light)">
-    <link rel="icon" href="/assets/favicon-dark-fill.png" type="image/png" media="(prefers-color-scheme: dark)">
-    <link rel="icon" href="/assets/favicon-light-fill.png" type="image/png">
+    <link rel="icon" type="image/png" href="/assets/favicon.png">
     <link rel="apple-touch-icon" href="/assets/apple-icon.png" sizes="192x192">
     
     <script defer src="https://cloud.umami.is/script.js" data-website-id="e21ce1e3-9e78-42f6-ac48-fd87995bedc0"></script>

--- a/now/index.html
+++ b/now/index.html
@@ -25,9 +25,7 @@
     <meta name="twitter:description" content="What I’m doing now.">
     <meta name="twitter:image" content="/assets/social-media-preview.png">
     
-    <link rel="icon" href="/assets/favicon-light-fill.png" type="image/png" media="(prefers-color-scheme: light)">
-    <link rel="icon" href="/assets/favicon-dark-fill.png" type="image/png" media="(prefers-color-scheme: dark)">
-    <link rel="icon" href="/assets/favicon-light-fill.png" type="image/png">
+    <link rel="icon" type="image/png" href="/assets/favicon.png">
     <link rel="apple-touch-icon" href="/assets/apple-icon.png" sizes="192x192">
     
     <link rel="alternate" type="application/rss+xml" title="Thu Le" href="/feed.xml">

--- a/uses.html
+++ b/uses.html
@@ -25,9 +25,7 @@
     <meta name="twitter:description" content="Tools and apps that are my daily drivers.">
     <meta name="twitter:image" content="/assets/social-media-preview.png">
     
-    <link rel="icon" href="/assets/favicon-light-fill.png" type="image/png" media="(prefers-color-scheme: light)">
-    <link rel="icon" href="/assets/favicon-dark-fill.png" type="image/png" media="(prefers-color-scheme: dark)">
-    <link rel="icon" href="/assets/favicon-light-fill.png" type="image/png">
+    <link rel="icon" type="image/png" href="/assets/favicon.png">
     <link rel="apple-touch-icon" href="/assets/apple-icon.png" sizes="192x192">
     
     <script defer src="https://cloud.umami.is/script.js" data-website-id="e21ce1e3-9e78-42f6-ac48-fd87995bedc0"></script>


### PR DESCRIPTION
## Summary
- simplify favicon handling by using one `/assets/favicon.png`
- restore `/assets/apple-icon.png` as the Apple touch icon

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688f537736f88325b108325cb6309b33